### PR TITLE
Feat(docs): Add doc for line ending errors

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,6 +26,7 @@ Fork this repository
 
 ``https://github.com/metabrainz/bookbrainz-site.git``
 
+.. _cloning-repository:
 
 Cloning
 *******
@@ -65,7 +66,7 @@ You'll need to install Docker and Docker-Compose on your development machine:
 * `Docker`_
 * `Docker-Compose`_
 
-.. important:: 
+.. important::
   We recommended Windows users to :doc:`docker-setup` (preferably WSL2) to avoid any compatibility issues.
   
 When it is installed, follow the below instructions step by step.
@@ -86,7 +87,7 @@ Luckily, we have a script that does just that: from the command line, in the ``b
 Running Web server
 ******************
 
-If all went well, you will only need to run ``./develop.sh`` in the command line from the ``bookbrainz-site`` folder. Press ``Ctrl+c`` to stop the server. 
+If all went well, you will only need to run ``./develop.sh`` in the command line from the ``bookbrainz-site`` folder. Press ``Ctrl+c`` to stop the server.
 
 .. note::
   The dependencies (postgres, redis,…) will continue to run in the background. To stop them, run the command ``./stop.sh``
@@ -140,10 +141,10 @@ These are described here; any commands not listed should not be called directly:
 * lint - check the code for syntax and style issues
 * test - perform linting and attempt to compile the code
 * jsdoc - build the documentation for JSDoc annotated functions within the
-  code 
+  code
 
 
-Installing dependencies manually 
+Installing dependencies manually
 ********************************
 
 If you don't want to use Docker for the dependencies, here are the steps you will need to take to get your local environment up and running.
@@ -204,7 +205,7 @@ Then, uncompress the ``latest.sql.bz2`` file, using the bzip2 command::
 This will give you a file that you can restore into PostgreSQL, which will
 set up data identical to the data we have on the bookbrainz.org website. First, you must create the necessary role and database with these two commands::
 
-    psql -h localhost -U postgres --command="CREATE ROLE bookbrainz"	
+    psql -h localhost -U postgres --command="CREATE ROLE bookbrainz"
     psql -h localhost -U postgres --command="CREATE DATABASE bookbrainz"
 
 Then you can restore the database from the lates dump you dowloaded. To do this, run::
@@ -334,11 +335,11 @@ Run the following command to create and set up the ``bookbrainz_test`` database 
 If you are running postgres manually outside of Docker, you can set some environment variables before running the script ``scripts/create-test-db.sh``.
 In particular ``POSTGRES_HOST=localhost`` but you can also set ``POSTGRES_USER``, ``POSTGRES_PASSWORD`` and ``POSTGRES_DB``.
 
-Once your testing database is set up, you can run the test suite using 
+Once your testing database is set up, you can run the test suite using
 
 * To run in Docker::
 
-      docker-compose run --rm bookbrainz-site yarn run test 
+      docker-compose run --rm bookbrainz-site yarn run test
 
 * To run locally::
 
@@ -347,5 +348,5 @@ Once your testing database is set up, you can run the test suite using
 .. note::
   You may need to adjust your ``config/test.json`` file to match your setup.
 
-.. seealso:: 
+.. seealso::
   If you face any issues, please refer to our :doc:`troubleshooting` section.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -37,8 +37,9 @@ General
   These errors may occur when running develop.sh or database-init-docker.sh during installation if git or another application
   has replaced Linux line endings (LF) with Windows line endings (CR LF) in certain .sh files.
 
-  To determine if this is the issue, you may open the .sh files using Notepad++ and check the bottom right corner. If any
-  file's line endings are indicated incorrectly as Windows (CR LF) you can resolve the issue by following these steps:
+  To determine if this is the issue, you may open the .sh files using an application such as Notepad++ or VS Code and check
+  the bottom right corner. If any file's line endings are indicated incorrectly as Windows (CR LF) you can resolve the issue
+  by following these steps:
 
   1. Navigate to the bookbrainz-site directory and configure git to clone repositories using the original line endings
   with the following command:

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -32,6 +32,31 @@ General
    
   Try running ``yarn run build-less`` or ``npm run build-less`` from the project directory.
 
+* ``[/usr/bin/env: 'bash\r': No such file or directory] or [exec scripts/wait-for-postgres.sh: no such file or directory]``
+
+  These errors may occur when running develop.sh or database-init-docker.sh during installation if git or another application
+  has replaced Linux line endings (LF) with Windows line endings (CR LF) in certain .sh files.
+
+  To determine if this is the issue, you may open the .sh files using Notepad++ and check the bottom right corner. If any
+  file's line endings are indicated incorrectly as Windows (CR LF) you can resolve the issue by following these steps:
+
+  1. Navigate to the bookbrainz-site directory and configure git to clone repositories using the original line endings
+  with the following command:
+  ::
+
+     git config --global core.autocrlf input
+
+  2. Delete the bookbrainz-site directory from its parent directory.
+  ::
+
+  3. Clone the bookbrainz repository again using the appropriate command (the URL will be different if cloning from a fork)
+  ::
+
+     git clone --recurse-submodules https://github.com/metabrainz/bookbrainz-site.git
+
+  4. The line endings should now be corrected and you may proceed with following the normal installation procedure.
+  ::
+
 Elasticsearch
 =============
 * Elasticsearch taking too much time?

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -48,15 +48,10 @@ General
      git config --global core.autocrlf input
 
   2. Delete the bookbrainz-site directory from its parent directory.
-  ::
 
-  3. Clone the bookbrainz repository again using the appropriate command (the URL will be different if cloning from a fork)
-  ::
-
-     git clone --recurse-submodules https://github.com/metabrainz/bookbrainz-site.git
+  3. Clone the bookbrainz repository again using the appropriate command. Follow the instructions here: :ref:`cloning-repository`
 
   4. The line endings should now be corrected and you may proceed with following the normal installation procedure.
-  ::
 
 Elasticsearch
 =============


### PR DESCRIPTION
**Problem**
Errors would sometimes occur during the bookbrainz-site installation process (specifically when running develop.sh and database-init-docker.sh) if Linux line endings were replaced by Windows line endings in certain script files. This was occurring on Windows machines due to a default git setting that would replace all line endings in cloned files with Window's line endings (CRLF).

**Solution**
The main source of this error was addressed in https://github.com/metabrainz/bookbrainz-site/commit/b7b3a805eaa624687f02599ce3f37b7cf242393e  which changed the .gitattributes file in the bookbrainz-site repository to override the git setting. However this error may still occur if an application besides git changes line endings, therefore this commit adds documentation in the Troubleshooting section that gives step-by-step instructions on how to resolve the issue by changing git configuration settings and re-cloning the bookbrainz-site repository. 