### PR TITLE
Update installation instructions to use a docker-compose override file

### DIFF
--- a/docs/ORM.rst
+++ b/docs/ORM.rst
@@ -50,7 +50,7 @@ Entities and their data
 =======================
 
 When we merge entities, their BBIDs get redirected to the entity we merged into.
-To ensure we are targetting the correct entity, we can use the `recursivelyGetRedirectBBID utility <https://metabrainz.github.io/bookbrainz-data-js/global.html#recursivelyGetRedirectBBID>`_:
+To ensure we are targeting the correct entity, we can use the `recursivelyGetRedirectBBID utility <https://metabrainz.github.io/bookbrainz-data-js/global.html#recursivelyGetRedirectBBID>`_:
 ``const redirectBbid = await orm.func.entity.recursivelyGetRedirectBBID(orm, relEntity.bbid, null);``
 
 To get an entity's current data (i.e. at the last revision) using its BBID, we can forge a new instance of the entity model

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -6,7 +6,7 @@ To allow users to authentication with BookBrainz, the webservice implements
 OAuth 2. We use the password grant type, meaning that clients must forward
 user credentials (username and password) to the website over HTTPS.
 
-When a client successfully authenticates a user, they recieve an access token,
+When a client successfully authenticates a user, they receive an access token,
 which must be sent in the header of every subsequent POST request.
 
 Example requests are shown below, for a username "Jim" and password "Bob123".

--- a/docs/entity-editor.rst
+++ b/docs/entity-editor.rst
@@ -81,9 +81,9 @@ Here, the fields ``disambiguation``, ``name``, ``sortName`` and ``language`` are
 Whenever we start entering any name in the Name field, we use the onChange event handler to fire off 4 different actions:
 
 * ``onNameChange``: this updates the *nameValue*.
-* ``onNameChangeSearchName``: as we enter the name, we try to seach the nameValue in our database in order to let the user see whether the entity already exists in our database. This updates the search term and adds the results in *searchResults*.
+* ``onNameChangeSearchName``: as we enter the name, we try to search the nameValue in our database in order to let the user see whether the entity already exists in our database. This updates the search term and adds the results in *searchResults*.
 * ``onNameChangeCheckIfExists``: if we find an entity whose name matches exactly with the entity name we entered, we try to display a warning so as to avoid the user from making a duplicate entry. This updates the content of *exactMatches*.
-* ``searchForMatchindEditionGroups``: Search for Edition Groups that match the name, if the entity is an Edition.
+* ``searchForMatchingEditionGroups``: Search for Edition Groups that match the name, if the entity is an Edition.
 
 Similarly, appropriate eventHandlers and actions are present for updating the value of *Sort Name* field, *Language*, and *Disambiguation*.
 
@@ -105,11 +105,11 @@ We make use of ``relationshipEditorVisible`` flag to toggle the Relationship edi
 
 **Entity Select field** : The *renderEntitySelect* function deals with this field. Here ``baseEntity`` is the entity which is being edited. The ``EntitySearchFieldOption`` allows us to search for any existing entity which we would like to link to our current *baseEntity*.
 
-We can apply some additional filters to our search, so as to the optimize search results. For example, in case of a Series entity of type X, we dont need to display search results with entities which are not of the same type.
+We can apply some additional filters to our search, so as to the optimize search results. For example, in case of a Series entity of type X, we don't need to display search results with entities which are not of the same type.
 When we select an entity from the Search results, it gets stored as ``targetEntity``.
 
 **RelationshipType Select field** : After selecting a targetEntity, we make use of a function called ``generateRelationshipSelection`` which takes our relationshipTypes object which was passed as a prop to our entity-editor, the baseEntity, and the targetEntity.
-This function returns all combinations of relationship types which are valid between the two entities. We can then select the Relationship Type for our entity using the RelationshipSelect field in the editor. This sets the value of ``relationship`` and ``relationsipType`` of our state.
+This function returns all combinations of relationship types which are valid between the two entities. We can then select the Relationship Type for our entity using the RelationshipSelect field in the editor. This sets the value of ``relationship`` and ``relationshipType`` of our state.
 
 When we click on Add, we pass the ``relationship`` object to the following action:
 ::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ Setting Up
 
 BookBrainz depends on having PostgreSQL, Redis, Elasticsearch and NodeJS set up and running.
 
-But first some basic configuration common to both docker and manual installation.
+But first some basic configuration common to both Docker and manual installation.
 
 Forking
 *******
@@ -32,21 +32,22 @@ Fork this repository
 Cloning
 *******
 
-To clone the repository and point the local HEAD to the latest commit in the stable branch, something like the following command should work
+To clone the repository and point the local HEAD to the latest commit in the stable branch, something like the following command should work:
 
 ::
-    
+
     git clone https://github.com/<Your_Github_Username>/bookbrainz-site.git
 
 Since this project makes use of git submodules, you need to use ``git clone --recurse-submodules`` to clone it.
 
-Alternatively, to manually initialize submodules, run these two commands
+Alternatively, to manually initialize submodules, run these two commands:
+
 ::
 
     git submodule init
     git submodule update
 
-Currently we are using these submodules
+Currently we are using these submodules:
 
 * `MonkeyDo/Lobes`_ in ``src/client/stylesheets/lobes``
 
@@ -73,21 +74,22 @@ You can then copy the tokens for that developer application and paste as strings
 
 Docker Installation
 ===================
+
 The easiest way to get a local development server running is using Docker. This will save you a fair amount of set up.
 
-You'll need to install Docker and Docker-compose on your development machine:
+You'll need to install Docker and Docker-Compose on your development machine:
 
 * `Docker`_
-*  `Docker-compose`_
+* `Docker-Compose`_
 
 .. important:: 
-  
   We recommended Windows users to :doc:`docker-setup` (preferably WSL2) to avoid any compatibility issues.
   
 When it is installed, follow the below instructions step by step.
 
 Database set-up
 ***************
+
 When you first start working with BookBrainz, you will need to perform some initialization for PostgreSQL and import the latest BookBrainz database dump.
 
 Luckily, we have a script that does just that: from the command line, in the ``bookbrainz-site`` folder, type and run ``./scripts/database-init-docker.sh``. The process may take a while as Docker downloads and builds the images. Let that run until the command returns.
@@ -97,6 +99,7 @@ Luckily, we have a script that does just that: from the command line, in the ``b
 
 Running Web server
 ******************
+
 If all went well, you will only need to run ``./develop.sh`` in the command line from the ``bookbrainz-site`` folder. Press ``Ctrl+c`` to stop the server. 
 
 .. note::
@@ -237,19 +240,21 @@ Search server setup
 
 In order for searching to work on your local server, you will need to index the contents of the database.
 
-1. first, ensure that Elasticsearch is running.
-2. add your user name (if you haven't created a user yet, `now is the time! <https://musicbrainz.org/doc/How_to_Create_an_Account>`) to the array of ``trustedUsers`` in the ``src/server/routes/search.js`` file
-3. with that done and the server (re)started, navigate to ``localhost:9099/search/reindex``
-    Reindexing will take a few minutes depending on your resources, and you can expect that the browser window will time out before the reindexing is done.
-    However the process will continue in the background and after a little while the search indices will be created.
-4. You can now try searching for an entity on the page ``localhost:9099/search``
+1. First, ensure that Elasticsearch is running.
+2. Add your user name (if you haven't created a user yet, `now is the time! <https://musicbrainz.org/doc/How_to_Create_an_Account>`_) to the array of ``trustedUsers`` in the ``src/server/routes/search.js`` file.
+3. With that done and the server (re)started, navigate to ``localhost:9099/search/reindex``.
+   Reindexing will take a few minutes depending on your resources, and you can expect that the browser window will time out before the reindexing is done.
+   However the process will continue in the background and after a little while the search indices will be created.
+4. You can now try searching for an entity on the page ``localhost:9099/search``.
 
-Advance Users
-=============
-To improve your developer experience, here are some things we suggest you should do
+Advanced Users
+==============
+
+To improve your developer experience, here are some things we suggest you should do.
 
 Live Reload
 ***********
+
 You may want to use Webpack to build, watch files and inject rebuilt pages without having to refresh the page, keeping the application state intact, for the price of increased compilation time and resource usage (see note below).
 
 If you are running the server manually, you can simply run ``yarn run debug`` in the command line.
@@ -291,6 +296,7 @@ We will achieve that by creating a ``.env`` file (in the repository's root direc
 
 Debugging with VSCode
 *********************
+
 You can use VSCode to run the server or API and take advantage of its debugger, an invaluable tool I highly recommend you learn to use.
 This will allow you to put breakpoints to stop and inspect the code and variables during its execution, advance code execution line by line and step into function calls, instead of putting console.log calls everywhere.
 
@@ -331,14 +337,15 @@ There are VSCode configuration files (in the ``.vscode`` folder) for running bot
 
 Testing
 =======
+
 The test suite is built using `Mocha <https://mochajs.org/>`_ and `Chai <https://www.chaijs.com/>`_. Before running the tests, you will need to set up a ``bookbrainz_test`` database in postgres. Here are the instructions to do so:
 
-Run the following command to create and set up the ``bookbrainz_test`` database using Docker
+Run the following command to create and set up the ``bookbrainz_test`` database using Docker:
 ::
 
     docker-compose run --rm bookbrainz-site scripts/wait-for-postgres.sh scripts/create-test-db.sh.
 
-If you are running postgres manually outside of Docker, you can set some environment variables before running the script `scripts/create-test-db.sh`
+If you are running postgres manually outside of Docker, you can set some environment variables before running the script ``scripts/create-test-db.sh``.
 In particular ``POSTGRES_HOST=localhost`` but you can also set ``POSTGRES_USER``, ``POSTGRES_PASSWORD`` and ``POSTGRES_DB``.
 
 Once your testing database is set up, you can run the test suite using 
@@ -350,11 +357,11 @@ Once your testing database is set up, you can run the test suite using
 
 * To run locally
 ::
-  
+
     yarn run test 
 
 .. note::
   You may need to adjust your ``config/test.json`` file to match your setup.
 
 .. seealso:: 
-  if you face any issues, please refer to our :doc:`troubleshooting` section.
+  If you face any issues, please refer to our :doc:`troubleshooting` section.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -306,8 +306,7 @@ This will allow you to put breakpoints to stop and inspect the code and variable
 Running the code with Docker
 ----------------------------
 
-If you're using Docker with our ``./develop.sh`` script, you will need to modify the ``docker-compose.yml`` file and change a few things on the ``bookbrainz-site`` service defined there.
-Make sure, you have the `Docker <https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker>`_ extension installed.
+If you're using Docker with our ``./develop.sh`` script, you will need to adapt your custom Compose file once again, or create a new one (see section above):
 
 1. Change the bookbrainz-site service's ``command`` to
 
@@ -325,10 +324,10 @@ For example:
       # 1. Change the command to run
         command: yarn run debug --inspect=0.0.0.0:9229
         ports:
-          - "9099:9099"
       # 2. Expose the port
           - "9229:9229"
 
+Now make sure that you have the `Docker <https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker>`_ extension installed.
 
 That's it, now you can just open the debugger tray in VSCode, select 'Docker: Attach to Node' and click the button!
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -126,10 +126,11 @@ Manual Installation
 If you do not want to use Docker (``./develop.sh``) to run the server on your machine, you can run the server code manually (regardless of whether you are running dependencies (database, search,…) with Docker or you are running them manually)
 So for setting up and running the NodeJS server outside of Docker -
 
-**Installing NodeJS**
+Installing NodeJS and Packages
+------------------------------
+
 To install NodeJS, follow the instruction for your operating system on the `official website <https://nodejs.org/en/download/>`_.
 
-**Installing Packages**
 The site depends on a number of node packages which can be installed using yarn (or npm):
 
 ::
@@ -139,7 +140,8 @@ The site depends on a number of node packages which can be installed using yarn 
 
 This command will also compile the site LESS and JavaScript source files.
 
-**Configuration**
+Configuration
+-------------
 
 Our ``config.example.json`` is set up to work out of the box running everything in Docker. Addresses for the dependencies refer to docker container names, so that containers can communicate with each other.
 
@@ -147,7 +149,9 @@ For local development (run outside of Docker), make a copy of `config/config.loc
 For example, ``yarn start -- --config ./config/config.local.json`` will use ``./config/config.local.json`` config instead of the Default config (``config.json`` for Docker).
 
 
-**Building and running**
+Building and running
+--------------------
+
 A number of subcommands exist to manage the installation and run the server.
 These are described here; any commands not listed should not be called directly:
 
@@ -161,10 +165,13 @@ These are described here; any commands not listed should not be called directly:
 
 Installing dependencies manually 
 ********************************
+
 If you don't want to use Docker for the dependencies, here are the steps you will need to take to get your local environment up and running.
 
-**PostgreSQL**
-BookBrainz uses version 12.3.To get PostgreSQL, use one of the following commands:
+PostgreSQL
+----------
+
+BookBrainz uses version 12.3. To get PostgreSQL, use one of the following commands:
 
 Debian-based OS
 ::
@@ -176,7 +183,9 @@ Red Hat-based OS
 
     sudo yum install postgresql-server
 
-**Redis**
+Redis
+-----
+
 To install Redis, run similar commands to get the dependency from your package
 manager:
 
@@ -191,7 +200,8 @@ Red Hat-based OS
     sudo yum install redis
 
 
-**Elasticsearch**
+Elasticsearch
+-------------
 
 To install Elasticsearch, follow `this helpful guide <https://www.digitalocean.com/community/tutorials/how-to-install-and-configure-elasticsearch-on-ubuntu-16-04) for Linux-based systems or the [official instructions](
 https://www.elastic.co/guide/en/elasticsearch/reference/6.3/install-elasticsearch.html>`_.
@@ -199,6 +209,7 @@ https://www.elastic.co/guide/en/elasticsearch/reference/6.3/install-elasticsearc
 The BookBrainz server has been tested with ElasticSearch version 6.3.2.
 
 Setting up Dependencies
+-----------------------
 
 No setup is required for Redis or Elasticsearch. However, it is necessary to
 perform some initialization for PostgreSQL and import the latest BookBrainz
@@ -307,6 +318,7 @@ This will allow you to put breakpoints to stop and inspect the code and variable
 
 Running the code with Docker
 ----------------------------
+
 If you're using Docker with our ``./develop.sh`` script, you will need to modify the ``docker-compose.yml`` file and change a few things on the ``bookbrainz-site`` service defined there.
 Make sure, you have the `Docker <https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker>`_ extension installed.
 
@@ -331,7 +343,7 @@ For example:
           - "9229:9229"
 
 
-That's it, now you can just open the debugger tray in VSCode, select 'Docker: Attach to Node ' and click the button!
+That's it, now you can just open the debugger tray in VSCode, select 'Docker: Attach to Node' and click the button!
 
 Running the code with VSCode
 ----------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,19 +38,6 @@ To clone the repository and point the local HEAD to the latest commit in the sta
 
     git clone https://github.com/<Your_Github_Username>/bookbrainz-site.git
 
-Since this project makes use of git submodules, you need to use ``git clone --recurse-submodules`` to clone it.
-
-Alternatively, to manually initialize submodules, run these two commands:
-
-::
-
-    git submodule init
-    git submodule update
-
-Currently we are using these submodules:
-
-* `MonkeyDo/Lobes`_ in ``src/client/stylesheets/lobes``
-
 Configuration
 *************
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -253,6 +253,8 @@ Advanced Users
 
 To improve your developer experience, here are some things we suggest you should do.
 
+.. _live-reload:
+
 Live Reload
 ***********
 
@@ -306,7 +308,7 @@ This will allow you to put breakpoints to stop and inspect the code and variable
 Running the code with Docker
 ----------------------------
 
-If you're using Docker with our ``./develop.sh`` script, you will need to adapt your custom Compose file once again, or create a new one (see section above):
+If you're using Docker with our ``./develop.sh`` script, you will need to adapt your custom Compose file once again, or create a new one (see :ref:`live-reload`):
 
 1. Change the bookbrainz-site service's ``command`` to
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -254,7 +254,7 @@ You may want to use Webpack to build, watch files and inject rebuilt pages witho
 
 If you are running the server manually, you can simply run ``yarn run debug`` in the command line.
 
-If you're using Docker and our ``./develop.sh`` script, you will need to modify the ``docker-compose.yml`` file and change a few things on the ``bookbrainz-site`` service defined there
+If you're using Docker and our ``./develop.sh`` script, you will need to create a custom Compose file and define a few overrides for the ``bookbrainz-site`` service there:
 
 1. Change the bookbrainz-site command to
 
@@ -272,9 +272,20 @@ For example:
       # 1. Change the command to run
         command: yarn run debug
         volumes:
-          - "./config/config.json:/home/bookbrainz/bookbrainz-site/config/config.json:ro"
       # 2. Mount the src directory
           - "./src:/home/bookbrainz/bookbrainz-site/src"
+
+Ideally you save this new Compose file inside the ``local/`` directory, which will be ignored by git, for example as ``local/docker-compose.live-reload.yml``.
+
+Now you have to explicitly tell Docker-Compose which Compose files it should read when the ``./develop.sh`` script is run.
+In addition to the default ``docker-compose.yml`` we also want Compose to read our custom file with the overrides.
+
+We will achieve that by creating a ``.env`` file (in the repository's root directory) which sets the ``COMPOSE_FILE`` environment variable, e.g.
+
+::
+
+    COMPOSE_FILE=docker-compose.yml:local/docker-compose.live-reload.yml
+
 .. warning::
   Using Webpack watch mode (``yarn run debug``) results in more resource consumption (about ~1GB increased RAM usage) compared to running the standard web server.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -73,7 +73,7 @@ You can then copy the tokens for that developer application and paste as strings
 
 Docker Installation
 ===================
-The easiest way to get a local developement server running is using Docker. This will save you a fair amount of set up.
+The easiest way to get a local development server running is using Docker. This will save you a fair amount of set up.
 
 You'll need to install Docker and Docker-compose on your development machine:
 
@@ -82,7 +82,7 @@ You'll need to install Docker and Docker-compose on your development machine:
 
 .. important:: 
   
-  We recommended Windows users to :doc:`docker-setup` (preferbly WSL2) to avoid any compatibility issues.
+  We recommended Windows users to :doc:`docker-setup` (preferably WSL2) to avoid any compatibility issues.
   
 When it is installed, follow the below instructions step by step.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -87,6 +87,9 @@ You'll need to install Docker and Docker-Compose on your development machine:
   
 When it is installed, follow the below instructions step by step.
 
+.. note::
+  After a fresh Docker installation, you need ~4GB of disk space for the container images, better more.
+
 Database set-up
 ***************
 

--- a/docs/musicbrainz.rst
+++ b/docs/musicbrainz.rst
@@ -26,7 +26,7 @@ An additional revision_parent table allows us to keep a tree of modifications.
 
 In additions to the versioning system, "deleting" an entity in BookBrainz is only ever a "soft delete",
 meaning we mark the entity as deleted but keep all their editing history.
-This allows us to resurect 'deleted' entities if need be.
+This allows us to resurrect 'deleted' entities if need be.
 
 Aliases
 =======
@@ -52,7 +52,7 @@ Merging
 =======
 Merging in BookBrainz is very similar to regular edits: we create a new revision for each entity, one of which will contain
 the new aggregated data from the merge. The new revision will be marked as being a merge operation, as well as each author_revision
-(using Authors as an ecample) for each of the merge entity.
+(using Authors as an example) for each of the merge entity.
 
 Let's say we're merging Author B and Author C into Author A. We select the correct value if there are any differences between entities,
 and the sets are combined (we add together the aliases, relationships, and identifiers).

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -231,7 +231,7 @@ alias, which indicates its original name. It can have many *primary* aliases,
 which give the most common names in particular languages. *Native* aliases will
 usually also be *primary*.
 
-A **disambiguation** allows us to differenciate between two entities with the same name.
+A **disambiguation** allows us to differentiate between two entities with the same name.
 All entities can have a disambiguation (although they are not required),
 referred to by a disambiguation_id, that points to the disambiguation table.
 


### PR DESCRIPTION
In addition to what the title promises, this PR also includes a note about the approximate disk space requirements of the Docker images.
While I was already at it, I also run a code spell checker over the repository, fixed the markup of a broken link and made the formatting (of the installation document) more consistent in general, see the individual commits.

Please note that I did not test the example override file but one with additional overrides to disable Elasticsearch on my broken setup.
I previewed the rendered installation file with GitHub, which does not support all features of RTD, but at least helped to avoid the simplest formatting mistakes.