### PR TITLE
Readthedocs config update

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,9 @@ build:
   tools:
     python: "3.12"
 
-mkdocs:
-  configuration: mkdocs.yml
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: conf.py
 
 # Optionally declare the Python requirements required to build your docs
 python:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Defining the exact version will make sure things don't break
+sphinx==5.3.0
+sphinx_rtd_theme==2.0.0


### PR DESCRIPTION
Some time since the last successful compilation 8 months ago, ReadTheDocs has apparently added a requirement to have a configuration file at the root of the repo, which I missed.
Creating this config file now based on https://docs.readthedocs.io/en/stable/config-file/v2.html