### PR TITLE
Fix broken link in the docs

### DIFF
--- a/docs/webservice.rst
+++ b/docs/webservice.rst
@@ -2,6 +2,6 @@
 BookBrainz Webservice/API
 #########################
 
-The BookBrainz API (currently in beta) provides developers with a way to make programs which
+The BookBrainz API provides developers with a way to make programs which
 use BookBrainz data.
 Documentation for the API is provided alongside the API itself: https://api.bookbrainz.org/1/docs/

--- a/docs/webservice.rst
+++ b/docs/webservice.rst
@@ -4,4 +4,4 @@ BookBrainz Webservice/API
 
 The BookBrainz API (currently in beta) provides developers with a way to make programs which
 use BookBrainz data.
-Documentation for the API is provided alongside the API itself: https://api.test.bookbrainz.org/1/docs/
+Documentation for the API is provided alongside the API itself: https://api.bookbrainz.org/1/docs/


### PR DESCRIPTION
Issue: [BB-878](https://tickets.metabrainz.org/browse/BB-878)

Updated a broken link in the Web Service documentation page:
[https://bookbrainz-dev-docs.readthedocs.io/en/latest/docs/webservice.html](https://bookbrainz-dev-docs.readthedocs.io/en/latest/docs/webservice.html)